### PR TITLE
Pass logger object into PhpInnacleConfigurator

### DIFF
--- a/src/Amqp/PhpInnacle/PhpInnacleConfigurator.php
+++ b/src/Amqp/PhpInnacle/PhpInnacleConfigurator.php
@@ -197,7 +197,7 @@ final class PhpInnacleConfigurator
                         $this->logger->debug(
                             'Linking "{exchangeName}" exchange to the exchange "{destinationExchangeName}" with the routing key "{routingKey}"',
                             [
-                                'queueName'               => $sourceExchange->name,
+                                'exchangeName'               => $sourceExchange->name,
                                 'destinationExchangeName' => $exchange->name,
                                 'routingKey'              => (string) $bind->routingKey,
                             ]

--- a/src/Amqp/PhpInnacle/PhpInnacleConfigurator.php
+++ b/src/Amqp/PhpInnacle/PhpInnacleConfigurator.php
@@ -197,7 +197,7 @@ final class PhpInnacleConfigurator
                         $this->logger->debug(
                             'Linking "{exchangeName}" exchange to the exchange "{destinationExchangeName}" with the routing key "{routingKey}"',
                             [
-                                'exchangeName'               => $sourceExchange->name,
+                                'exchangeName'            => $sourceExchange->name,
                                 'destinationExchangeName' => $exchange->name,
                                 'routingKey'              => (string) $bind->routingKey,
                             ]

--- a/src/Amqp/PhpInnacle/PhpInnacleTransport.php
+++ b/src/Amqp/PhpInnacle/PhpInnacleTransport.php
@@ -242,7 +242,10 @@ final class PhpInnacleTransport implements Transport
                 /** @var Channel $channel */
                 $channel = yield $this->client->channel();
 
-                $configurator = new PhpInnacleConfigurator($channel);
+                $configurator = new PhpInnacleConfigurator(
+                    channel: $channel,
+                    logger: $this->logger
+                );
 
                 yield $configurator->doCreateExchange($amqpExchange);
                 yield $configurator->doBindExchange($amqpExchange, $binds);
@@ -269,7 +272,10 @@ final class PhpInnacleTransport implements Transport
                 /** @var Channel $channel */
                 $channel = yield $this->client->channel();
 
-                $configurator = new PhpInnacleConfigurator($channel);
+                $configurator = new PhpInnacleConfigurator(
+                    channel: $channel,
+                    logger: $this->logger
+                );
 
                 yield $configurator->doCreateQueue($amqpQueue);
                 yield $configurator->doBindQueue($amqpQueue, $binds);


### PR DESCRIPTION
Now `PhpInnacleConfigurator` always uses `NullLogger`, but we can pass the actual logger that `PhpInnacleTransport` use when creating the `PhpInnacleConfigurator` object.